### PR TITLE
[v. 0.24] PVS/LMR Re-search Optimization

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1123,17 +1123,21 @@ int search(Position& pos, int depth, int alpha, int beta, int ply, bool is_pv_no
                 if (R_lmr < 0) R_lmr = 0;
             }
 
+            // --- LMR/PVS FIX STARTS HERE ---
             // Search with reduced depth and null window
             score = -search(next_pos, depth - 1 - R_lmr, -alpha - 1, -alpha, ply + 1, false, true, current_search_path_hashes);
 
             // If LMR failed high (score > alpha) and a reduction was applied, re-search with full depth
-            if (R_lmr > 0 && score > alpha) {
-                 score = -search(next_pos, depth - 1, -alpha - 1, -alpha, ply + 1, false, true, current_search_path_hashes);
-            }
-            // If PVS null window search still failed high, re-search with full window
-            if (score > alpha && score < beta) { // Only if it's a PV node candidate
+            // THIS BLOCK IS REMOVED AS IT'S A REDUNDANT RE-SEARCH WITH A NULL WINDOW
+            // if (R_lmr > 0 && score > alpha) {
+            //      score = -search(next_pos, depth - 1, -alpha - 1, -alpha, ply + 1, false, true, current_search_path_hashes);
+            // }
+            
+            // If the PVS null window search (or the LMR search) failed high, a re-search with the full window is required.
+            if (score > alpha && score < beta) { 
                  score = -search(next_pos, depth - 1, -beta, -alpha, ply + 1, false, true, current_search_path_hashes); // Re-search with full window
             }
+            // --- LMR/PVS FIX ENDS HERE ---
         }
 
         if (stop_search_flag) { current_search_path_hashes.pop_back(); return 0; }

--- a/main.cpp
+++ b/main.cpp
@@ -1123,21 +1123,14 @@ int search(Position& pos, int depth, int alpha, int beta, int ply, bool is_pv_no
                 if (R_lmr < 0) R_lmr = 0;
             }
 
-            // --- LMR/PVS FIX STARTS HERE ---
             // Search with reduced depth and null window
             score = -search(next_pos, depth - 1 - R_lmr, -alpha - 1, -alpha, ply + 1, false, true, current_search_path_hashes);
 
-            // If LMR failed high (score > alpha) and a reduction was applied, re-search with full depth
-            // THIS BLOCK IS REMOVED AS IT'S A REDUNDANT RE-SEARCH WITH A NULL WINDOW
-            // if (R_lmr > 0 && score > alpha) {
-            //      score = -search(next_pos, depth - 1, -alpha - 1, -alpha, ply + 1, false, true, current_search_path_hashes);
-            // }
-            
+            // If LMR failed high (score > alpha) and a reduction was applied, re-search with full depth            
             // If the PVS null window search (or the LMR search) failed high, a re-search with the full window is required.
             if (score > alpha && score < beta) { 
                  score = -search(next_pos, depth - 1, -beta, -alpha, ply + 1, false, true, current_search_path_hashes); // Re-search with full window
             }
-            // --- LMR/PVS FIX ENDS HERE ---
         }
 
         if (stop_search_flag) { current_search_path_hashes.pop_back(); return 0; }
@@ -1305,7 +1298,7 @@ void uci_loop() {
         ss >> token;
 
         if (token == "uci") {
-            std::cout << "id name Amira 0.23\n";
+            std::cout << "id name Amira 0.24\n";
             std::cout << "id author ChessTubeTree\n";
             std::cout << "option name Hash type spin default " << TT_SIZE_MB_DEFAULT << " min 0 max 1024\n";
             std::cout << "uciok\n" << std::flush;


### PR DESCRIPTION
The engine implements Late Move Reduction (LMR), a technique where moves ordered later in the list are searched with a reduced depth. This is combined with Principal Variation Search (PVS), where most moves are first explored with a "null window" (-alpha - 1, -alpha) to quickly prove they are not better than the current best move.
If a move searched with LMR or with a null window unexpectedly returns a score greater than alpha (a "fail-high"), it indicates the move is promising and must be re-searched with the full depth and full window to get an accurate score.
The current implementation has a redundant re-search step that harms performance. When an LMR search fails high, the code performs a re-search at full depth but still using a null window. Only if that search also fails high does it finally perform the required re-search with the full window. This intermediate re-search is unnecessary and wastes valuable time, as it doesn't produce the final accurate score needed. The correct approach is to proceed directly from the initial fail-high to the full-depth, full-window re-search.