### PR TITLE
[1.36] Implement Counter-Move Heuristic and Table-Driven LMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Amira Chess Engine
 
 **Author:** ChessTubeTree (Fauzi)
-**Version:** 1.35
+**Version:** 1.36
 
 ## Description
 


### PR DESCRIPTION
### Implement Counter-Move Heuristic and Table-Driven LMR

**Summary**

This pull request introduces two significant refinements to Amira's search algorithm aimed at improving efficiency and tactical accuracy. The static Late Move Reductions (LMR) have been replaced with a dynamic, table-driven system, and the move ordering has been enhanced with the counter-move heuristic. These changes make the search smarter, allowing it to prune unpromising branches more effectively and focus on critical moves faster.

### Detailed Changes

#### 1. Table-Driven Late Move Reductions (LMR)

The previous LMR logic relied on a fixed set of conditions to decide when and how much to reduce the search depth. This has been upgraded to a more flexible and powerful system.

*   **Dynamic Reductions:** A `search_reductions[depth][move_number]` table is now pre-calculated at startup. This table contains reduction values based on a logarithmic formula that considers both the remaining search depth and the number of moves already tried at a node.
*   **Benefits:**
    *   **Improved Pruning:** The search can now apply more aggressive reductions in positions where it is safe to do so (deep in the search, late in the move list), saving a significant amount of time.
    *   **Greater Accuracy:** The reductions are more conservative at shallower depths, reducing the risk of tactical oversights.
    *   **Tuning Capability:** The underlying formula provides a simple and effective way to tune the LMR aggressiveness in the future.

#### 2. Refutation Move Heuristic (Counter-Move Heuristic)

To improve move ordering for quiet (non-capture) moves, the counter-move heuristic has been implemented. This powerful technique helps the engine quickly find refutations to the opponent's threats.

*   **Mechanism:** A `refutation_moves[from_sq][to_sq]` table now stores the move that most effectively refutes the opponent's last move. When a quiet move causes a beta cutoff, it is saved as the "counter-move" to the move that preceded it.
*   **Benefits:**
    *   **Faster Cutoffs:** In `score_moves`, the refutation move is now given a high priority, just behind promotions and ahead of killer moves. This often leads to finding the best move earlier in the search.
    *   **Stronger Defense:** The engine becomes much better at finding key defensive moves that parry an opponent's tactical ideas.

### Rationale & Benefits

*   **More Efficient Search:** By pruning the search tree more intelligently, Amira can explore relevant variations to a greater depth in the same amount of time.
*   **Enhanced Tactical Vision:** The counter-move heuristic significantly improves the ordering of critical quiet moves, allowing the engine to spot both threats and defensive resources more quickly.
*   **Increased Playing Strength:** A more efficient and tactically aware search directly translates to stronger play, especially in complex middlegame positions.