### PR TITLE
[1.41]  Prevent LMR Array Out-of-Bounds Read at Max Depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Amira Chess Engine
 
 **Author:** ChessTubeTree (Fauzi)
-**Version:** 1.4
+**Version:** 1.41
 
 ## Description
 

--- a/main.cpp
+++ b/main.cpp
@@ -1574,7 +1574,7 @@ int search(Position& pos, int depth, int alpha, int beta, int ply, bool is_pv_no
             } else {
                 int R_lmr = 0;
                 // Late Move Reductions (LMR) with table
-                if (depth >= 3 && i >= 1 && !in_check && current_move.promotion == NO_PIECE &&
+                if (depth >= 3 && depth < MAX_PLY && i >= 1 && !in_check && current_move.promotion == NO_PIECE &&
                     pos.piece_on_sq(current_move.to) == NO_PIECE) {
                     R_lmr = search_reductions[depth][i];
                 }
@@ -1775,7 +1775,7 @@ void uci_loop() {
         ss >> token;
 
         if (token == "uci") {
-            std::cout << "id name Amira 1.4\n";
+            std::cout << "id name Amira 1.41\n";
             std::cout << "id author ChessTubeTree\n";
             std::cout << "option name Hash type spin default " << TT_SIZE_MB_DEFAULT << " min 0 max 1024\n";
             std::cout << "uciok\n" << std::flush;


### PR DESCRIPTION
 Prevent LMR Array Out-of-Bounds Read at Max Depth

Resolves: A critical and elusive bug causing the engine to freeze (reported as a "disconnect" or "abandon") in deep endgame scenarios. This issue occurred intermittently, typically when the search reached its maximum depth limit near a draw.

Summary:
After an extensive debugging process involving log analysis, we identified that the engine was not crashing but freezing during the search. The freeze occurred precisely when the iterative deepening loop in the uci_loop called the search function with depth = 128 (MAX_PLY).

The root cause was an out-of-bounds array access in the Late Move Reductions (LMR) logic.

Root Cause Analysis:
Maximum Depth: The go command in the uci_loop allows the search to iterate up to max_depth_to_search, which defaults to MAX_PLY (128). The loop is for (int depth = 1; depth <= max_depth_to_search; ++depth).

Array Declaration: The LMR table is declared as int search_reductions[MAX_PLY][256]. Since C++ arrays are 0-indexed, the valid indices for the first dimension are 0 through 127.

Out-of-Bounds Read: When the search was called with depth = 128, the condition if (depth >= 3 ...) in the LMR logic was met. The code then attempted to access search_reductions[128][i], which is one element beyond the array's bounds.

The "Freeze": Reading from this out-of-bounds memory location did not cause an immediate segmentation fault. Instead, it returned a garbage value. This garbage value was assigned to R_lmr and used to calculate the new search depth: depth - 1 - R_lmr. If R_lmr was a large negative number, this resulted in a recursive call to search with an impossibly large depth (e.g., over 2 billion). The engine was not stuck in a tight loop but was performing a legitimate, but astronomically long, search that would never complete, causing it to time out. This perfectly explains why the engine appeared to freeze without crashing.

The Fix:
The solution is to add a bounds check to the LMR logic, ensuring the search_reductions table is never accessed with an index equal to or greater than MAX_PLY.