### PR TITLE
[1.46] Store static evaluation in Transposition Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Amira Chess Engine
 
 **Author:** ChessTubeTree (Fauzi)
-**Version:** 1.45
+**Version:** 1.46
 
 ## Description
 


### PR DESCRIPTION
**Search: Store static evaluation in Transposition Table**

This pull request introduces a key optimization to the search algorithm by caching static evaluation scores in the transposition table (TT).

**Summary of Changes:**

- The `TTEntry` struct has been expanded to include the `static_eval` of the position.
- The `store_tt` function now saves the static evaluation along with other search data.
- The `probe_tt` function retrieves the cached static evaluation on a TT hit.
- The main `search` function has been updated to use this cached evaluation, avoiding redundant calls to `evaluate()`.

**Reasoning and Benefits:**

Previously, the engine would re-calculate the static evaluation for a position even if it was found in the TT. The `evaluate()` function is computationally expensive, and these repeated calls consumed a significant amount of CPU time.

By caching the static score, we leverage the TT more effectively. This results in:
- **Increased Nodes Per Second (NPS):** The search becomes faster as it spends less time on redundant evaluations.
- **Deeper Search:** With the same amount of time, the engine can now explore the search tree to a greater depth.
- **Stronger Play:** The ability to search deeper directly translates to better move choices and an overall increase in playing strength.

This is a pure performance enhancement that improves the efficiency of the search without altering its fundamental logic.