### PR TITLE
[1.62] Implement SEE-Based Pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Amira Chess Engine
 
 **Author:** ChessTubeTree (Fauzi)
-**Version:** 1.61
+**Version:** 1.62
 
 ## Description
 

--- a/main.cpp
+++ b/main.cpp
@@ -1858,6 +1858,21 @@ int search(Position& pos, int depth, int alpha, int beta, int ply, bool is_pv_no
         // Cache if the move is quiet using fast bitboard checks
         bool is_quiet = !(get_bit(opp_pieces, current_move.to) || (current_move.to == pos.ep_square && get_bit(friendly_pawns, current_move.from))) && current_move.promotion == NO_PIECE;
 
+        // --- Static Exchange Evaluation (SEE) Pruning ---
+        // If a move is unlikely to win material, we can prune it at shallow depths.
+        // This is especially effective for moves with low scores from the move picker.
+        if ( !is_pv_node && depth <= 8 && best_score > -MATE_THRESHOLD )
+        {
+            // Define aggressive margins that become stricter at deeper depths.
+            int see_margin = is_quiet ? -80 * depth
+                                      : -30 * depth * depth;
+
+            // Prune the move if its SEE value is below the margin.
+            if (see(pos, current_move) < see_margin) {
+                continue;
+            }
+        }
+
         legal_moves_played++;
         int score;
         bool is_repetition = false;
@@ -2100,7 +2115,7 @@ void uci_loop() {
         ss >> token;
 
         if (token == "uci") {
-            std::cout << "id name Amira 1.61\n";
+            std::cout << "id name Amira 1.62\n";
             std::cout << "id author ChessTubeTree\n";
             std::cout << "option name Hash type spin default " << TT_SIZE_MB_DEFAULT << " min 0 max 16384\n";
             std::cout << "uciok\n" << std::flush;


### PR DESCRIPTION
**Implement SEE-Based Pruning**

This change introduces Static Exchange Evaluation (SEE) based pruning to the main search algorithm. This is a standard and highly effective optimization that allows the engine to quickly discard moves that are tactically unfavorable without performing a costly recursive search.

The implementation prunes both quiet moves and losing captures if their SEE value is below a dynamic, depth-dependent threshold. This saves a significant amount of time, allowing the search to focus on more promising lines and achieve greater depths.