### PR TITLE
[1.65] Enhance Strategic Evaluation for Pawns and Rooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Amira Chess Engine
 
 **Author:** ChessTubeTree (Fauzi)
-**Version:** 1.64
+**Version:** 1.65
 
 ## Description
 


### PR DESCRIPTION
**Enhance Strategic Evaluation for Pawns and Rooks**

This pull request introduces two significant enhancements to the evaluation function, aimed at improving Amira's strategic understanding of pawn structures and rook activity.

---

### 1. Implement Granular Connected Pawn Evaluation

-   **Before:** The engine used a single, constant bonus (`PAWN_CONNECTED_BONUS`) for any pair of connected pawns, regardless of their position.
-   **After:** A new `PhalanxPawnBonus[file][rank]` table has been implemented. This provides a granular, two-phased bonus (middlegame and endgame) that correctly values connected pawns based on their file and how far they have advanced.
-   **Benefit:** This change provides a much more accurate assessment of pawn structure strength, especially rewarding advanced and central connected pawns more appropriately.

### 2. Improve "Rook on the Seventh Rank" Logic

-   **Before:** A simple bonus was applied whenever a rook reached the seventh rank.
-   **After:** The logic is now more intelligent:
    -   The `RookOnEnemyTerritoryBonus` is now only applied if there are tangible targets (the enemy king on the back rank or enemy pawns on the seventh rank).
    -   A new `ConnectedRooksOnTerritoryBonus` is added if two major pieces are connected on the seventh rank, recognizing this powerful attacking formation.
-   **Benefit:** This leads to better decision-making, as the engine now understands *why* a rook on the seventh is strong and can better evaluate the ensuing tactical possibilities.

These changes are expected to make Amira's play more strategically sound and positionally aware.